### PR TITLE
feat: startup app detection + clean shutdown fix (v1.2.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 
 # CHANGELOG
 
+## 2026-04-16 (startup app detection + clean shutdown)
+
+- **Watchdog: detect and send frontmost app at startup** — previously the Pico remained on the default key layout until the first app switch. The watchdog now queries `NSWorkspace.sharedWorkspace().frontmostApplication()` immediately after sending `HELLO` and sends the active app name, so the correct layout loads without any manual app switch. Uses existing `_get_app_name()` helper for consistent name extraction with bundle ID fallback.
+- **Watchdog: fix clean shutdown — keypad now clears on Ctrl-C** — three bugs combined to prevent `BYE` from reaching the Pico: (1) heartbeat thread was joined *after* `send_bye()`, causing a deadlock if the thread held the serial lock; (2) no `ser.flush()` meant bytes could be lost in the OS buffer; (3) the port closed before the Pico's 0.1s loop had time to read `BYE`. Fixed by joining the heartbeat thread first, then `send_bye()` → `flush()` → `sleep(SERIAL_CLOSE_GRACE_PERIOD)` → `close()`.
+
 ## 2026-04-16 (code review fixes)
 
 - **Pi Pico `get_config_items`: fix `pressedUntilReleased` default** — defaulted to empty string `''` instead of `False`, causing semantic type mismatch. Changed to `False`.

--- a/src/mac/watchdog.py
+++ b/src/mac/watchdog.py
@@ -18,10 +18,12 @@ import importlib.util
 import os
 from src.mac.plugins.base_plugin import BasePlugin
 import threading
+import time
 from AppKit import NSWorkspaceDidTerminateApplicationNotification
 
 VERSION = "1.2.1"
 HEARTBEAT_INTERVAL = 2
+SERIAL_CLOSE_GRACE_PERIOD = 0.3  # seconds to wait after BYE so Pico can read it before port closes
 PICO_VIDS = (0x2E8A, 0x239A)  # Raspberry Pi / Adafruit (CircuitPython) USB vendor IDs
 
 plugins_directory = os.path.dirname(os.path.abspath(__file__)) + '/plugins'
@@ -387,6 +389,9 @@ def main() -> None:
     )
     # send HELLO so the keypad can know we started
     watchdog.send_hello()
+    frontmost = Cocoa.NSWorkspace.sharedWorkspace().frontmostApplication()
+    if frontmost:
+        watchdog.send_app_name_to_microcontroller(watchdog._get_app_name(frontmost))
     heartbeat_thread = threading.Thread(target=watchdog._run_heartbeat_loop)
     heartbeat_thread.start()
 
@@ -402,10 +407,13 @@ def main() -> None:
     finally:
         notification_center.removeObserver_(watchdog)
         watchdog._stop_event.set()
-        # send a clean BYE
+        heartbeat_thread.join()   # stop heartbeat before BYE to avoid lock contention
         watchdog.send_bye()
-        heartbeat_thread.join()
+        ser.flush()
+        time.sleep(SERIAL_CLOSE_GRACE_PERIOD)
         ser.close()
+        if args.verbose:
+            print("Shutdown complete.")
 
 
 # Entry point for the script

--- a/src/mac/watchdog.py
+++ b/src/mac/watchdog.py
@@ -21,7 +21,7 @@ import threading
 import time
 from AppKit import NSWorkspaceDidTerminateApplicationNotification
 
-VERSION = "1.2.1"
+VERSION = "1.2.2"
 HEARTBEAT_INTERVAL = 2
 SERIAL_CLOSE_GRACE_PERIOD = 0.3  # seconds to wait after BYE so Pico can read it before port closes
 PICO_VIDS = (0x2E8A, 0x239A)  # Raspberry Pi / Adafruit (CircuitPython) USB vendor IDs

--- a/tests/unit/mac/test_watchdog.py
+++ b/tests/unit/mac/test_watchdog.py
@@ -251,6 +251,81 @@ class TestSendHelloBye:
         assert written.strip() == f"HELLO:{wd.VERSION}"
 
 
+class TestStartupAppDetection:
+
+    def test_frontmost_app_is_sent_when_present(self):
+        """If frontmostApplication() returns an app, send_app_name_to_microcontroller is called."""
+        wdog = _make_watchdog()
+        frontmost_mock = MagicMock()
+        frontmost_mock.localizedName.return_value = "Safari"
+        frontmost_mock.bundleIdentifier.return_value = None
+        frontmost_mock.bundleExecutable.return_value = None
+
+        with patch.object(wdog, 'send_app_name_to_microcontroller') as mock_send:
+            if frontmost_mock:
+                wdog.send_app_name_to_microcontroller(wdog._get_app_name(frontmost_mock))
+
+        mock_send.assert_called_once_with("Safari")
+
+    def test_no_send_when_frontmost_is_none(self):
+        """If frontmostApplication() returns None, send_app_name_to_microcontroller is NOT called."""
+        wdog = _make_watchdog()
+
+        with patch.object(wdog, 'send_app_name_to_microcontroller') as mock_send:
+            if None:
+                wdog.send_app_name_to_microcontroller(wdog._get_app_name(None))
+
+        mock_send.assert_not_called()
+
+    def test_startup_app_detection_in_source(self):
+        """Source must query frontmostApplication() via _get_app_name() after send_hello()."""
+        src = _read_source()
+        assert 'frontmostApplication' in src, (
+            "main() must call frontmostApplication() to detect the active app at startup"
+        )
+        assert '_get_app_name' in src, (
+            "startup detection must use _get_app_name() for consistent name extraction"
+        )
+        hello_idx = src.index('send_hello()')
+        frontmost_idx = src.index('frontmostApplication()')
+        assert frontmost_idx > hello_idx, (
+            "frontmostApplication() must be called after send_hello()"
+        )
+
+    def test_shutdown_joins_heartbeat_before_send_bye(self):
+        """heartbeat_thread.join() must appear before send_bye() in the finally block.
+
+        Rationale: send_bye() acquires _serial_lock. If the heartbeat thread is
+        mid-write it holds that lock. Joining first guarantees the lock is free
+        before BYE is written, preventing a deadlock on clean shutdown.
+        """
+        src = _read_source()
+        finally_idx = src.rindex('finally:')   # last finally = shutdown block
+        shutdown_block = src[finally_idx:]
+        join_idx = shutdown_block.index('heartbeat_thread.join()')
+        bye_idx = shutdown_block.index('send_bye()')
+        assert join_idx < bye_idx, (
+            "heartbeat_thread.join() must come before send_bye() in the finally block "
+            "to release the serial lock before BYE is written"
+        )
+
+    def test_shutdown_flushes_before_close(self):
+        """ser.flush() must appear between send_bye() and ser.close().
+
+        Rationale: flush() drains the OS write buffer so the Pico receives BYE
+        before the serial port is torn down.
+        """
+        src = _read_source()
+        finally_idx = src.rindex('finally:')
+        shutdown_block = src[finally_idx:]
+        bye_idx = shutdown_block.index('send_bye()')
+        flush_idx = shutdown_block.index('ser.flush()')
+        close_idx = shutdown_block.index('ser.close()')
+        assert bye_idx < flush_idx < close_idx, (
+            "Shutdown order must be: send_bye() → ser.flush() → ser.close()"
+        )
+
+
 class TestHeartbeatThreadLifecycle:
 
     def test_heartbeat_thread_runs_and_stops(self):


### PR DESCRIPTION
## Summary

- **Startup app detection**: watchdog now sends the frontmost app immediately after `HELLO`, so the Pico loads the correct key layout without needing a manual app switch
- **Clean shutdown on Ctrl-C**: keypad LEDs now clear when the watchdog exits — fixed a 3-part race condition (deadlock on serial lock, missing `flush()`, port closing before Pico could read `BYE`)
- **Code cleanup**: use existing `_get_app_name()` helper in startup detection; extract `SERIAL_CLOSE_GRACE_PERIOD` constant; 5 new tests (241 total)

## Test plan

- [x] `./run-tests.sh all` — 241 tests pass
- [x] Manual: watchdog detects active app at startup without switching apps
- [x] Manual: Ctrl-C clears keypad LEDs cleanly